### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-dotenv==1.0.0
 streamlit==1.18.1
 openai==0.27.6
 faiss-cpu==1.7.4
+altair==4.0
 
 # uncomment to use huggingface llms
 # huggingface-hub==0.14.1


### PR DESCRIPTION
The `altair==4.0` if not present will trow this error
```python
from altair.vegalite.v4.api import Chart
ModuleNotFoundError: No module named 'altair.vegalite.v4'
```