### PR TITLE
Replace PyPDF2 with pypdfium2 

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from dotenv import load_dotenv
 from PyPDF2 import PdfReader
+import pypdfium2 as pdfium
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.embeddings import OpenAIEmbeddings, HuggingFaceInstructEmbeddings
 from langchain.vectorstores import FAISS
@@ -10,12 +11,15 @@ from langchain.chains import ConversationalRetrievalChain
 from htmlTemplates import css, bot_template, user_template
 from langchain.llms import HuggingFaceHub
 
+
 def get_pdf_text(pdf_docs):
     text = ""
     for pdf in pdf_docs:
-        pdf_reader = PdfReader(pdf)
-        for page in pdf_reader.pages:
-            text += page.extract_text()
+        pdf_reader = pdfium.PdfDocument(pdf)
+        for i in range(len(pdf_reader)):
+            page = pdf_reader.get_page(i)
+            textpage = page.get_textpage()
+            text += textpage.get_text_range() + "\n"
     return text
 
 
@@ -88,7 +92,7 @@ def main():
             with st.spinner("Processing"):
                 # get pdf text
                 raw_text = get_pdf_text(pdf_docs)
-
+                print(raw_text)
                 # get the text chunks
                 text_chunks = get_text_chunks(raw_text)
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 import streamlit as st
 from dotenv import load_dotenv
-from PyPDF2 import PdfReader
 import pypdfium2 as pdfium
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.embeddings import OpenAIEmbeddings, HuggingFaceInstructEmbeddings
@@ -92,7 +91,6 @@ def main():
             with st.spinner("Processing"):
                 # get pdf text
                 raw_text = get_pdf_text(pdf_docs)
-                print(raw_text)
                 # get the text chunks
                 text_chunks = get_text_chunks(raw_text)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 langchain==0.0.184
-PyPDF2==3.0.1
 python-dotenv==1.0.0
 streamlit==1.18.1
 openai==0.27.6
 faiss-cpu==1.7.4
 altair==4
 tiktoken==0.4.0
+pypdfium2==4.18.0
 # uncomment to use huggingface llms
 # huggingface-hub==0.14.1
 


### PR DESCRIPTION
I really appreciate @alejandro-ao for creating good video demonstrating the perfect blend of openai, PDF readers and streamlit!

I've tried to use the tool for several PDFs, I found that there's an issue of text extraction quality using PyPDF2, that contexts of a PDF are not extracted fully and completely. 

After looking into https://github.com/py-pdf/benchmarks, it seems we can go with [pypdfium2](https://pypi.org/project/pypdfium2/) that serves similar functionality, while providing better text extraction quality and faster computational time (Verified from my end!)